### PR TITLE
Add commit-msg hook to enforce Developer Certificate of Origin (DCO) sign-off.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -40,3 +40,11 @@
   always_run: true
   description: 'checks if staged files contain the string "FORBIDDEN-COMMITTING"'
   stages: ['pre-commit']
+- id: check-dco
+  name: 'check DCO'
+  entry: check-dco.sh
+  pass_filenames: true
+  language: "script"
+  always_run: true
+  description: 'check if the commiting is signed with DCO'
+  stages: ['commit-msg']

--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ Add this to your .pre-commit-config.yaml:
 ### `forbidden-committing`
 
 This script is a pre-commit hook that checks if any staged file's content contains the string "FORBIDDEN-COMMITTING". If it does, the commit is aborted.
+
+### `check-dco`
+
+Check if the commit message is signed with DCO.
+To sign a commit, use `git commit -s`.

--- a/check-dco.sh
+++ b/check-dco.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+    exit 0
+fi
+
 if [ -z "$1" ]; then
     echo "Missing commit message file" >&2
     exit 1

--- a/check-dco.sh
+++ b/check-dco.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    echo "Missing commit message file" >&2
+    exit 1
+fi
+
+if [ ! -f "$1" ]; then
+    echo "File not found: $1" >&2
+    exit 1
+fi
+
+user=$(git config --get user.name)
+if ! grep -q "Signed-off-by: $user" "$1"; then
+    echo "Sign-off not found" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This pull request introduces a new pre-commit hook to enforce Developer Certificate of Origin (DCO) signing on all commits. This is a common practice in open-source projects, including many Linux Foundation projects, to certify that contributions are made under a specific license. Enforcing DCO helps maintain legal clarity and ensures proper attribution for all contributions.

This change helps to:

* Ensure all contributions are properly signed off, indicating agreement with the project's licensing terms.
* Improve the legal traceability of code contributions.
* Align with best practices for open-source project governance.

### Changes in this PR

* **Added `check-dco` pre-commit hook:** A new hook has been added to `.pre-commit-hooks.yaml` that runs during the `commit-msg` stage to verify the presence of a DCO signature.
* **Created `check-dco.sh` script:** This new executable script performs the actual check, ensuring that the commit message includes a "Signed-off-by:" line matching the committer's Git user name.
* **Updated `README.md`:** Documentation for the new `check-dco` hook has been added, explaining its purpose and how to sign a commit (`git commit -s`).

### Closed Issues

Close #3
