### PR TITLE
fix: skip forbidden push remote check for explicit remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ To sign a commit, use `git commit -s`.
 
 Prevent pushing to a remote that contains a specific string in its URL.
 This is useful to prevent accidental pushes to upstream repositories.
+When the `git push` command explicitly targets the current remote, this hook skips the check.
 Add this to your .pre-commit-config.yaml:
 
 ```yaml

--- a/forbidden-push-remote.sh
+++ b/forbidden-push-remote.sh
@@ -2,6 +2,150 @@
 
 set -e
 
+is_positive_integer() {
+    case "$1" in
+        '' | *[!0-9]*)
+            return 1
+            ;;
+    esac
+
+    [ "$1" -gt 0 ]
+}
+
+parent_command() {
+    ps -o command= -p "$1" 2>/dev/null || true
+}
+
+parent_pid() {
+    ps -o ppid= -p "$1" 2>/dev/null | tr -d ' ' || true
+}
+
+is_git_push_command() {
+    local command=$1
+    local -a parts
+
+    read -r -a parts <<< "$command" || true
+
+    for ((i = 0; i < ${#parts[@]}; i++)); do
+        if [ "${parts[$i]}" != "push" ]; then
+            continue
+        fi
+
+        for ((j = 0; j < i; j++)); do
+            case "${parts[$j]}" in
+                git | */git)
+                    return 0
+                    ;;
+            esac
+        done
+
+        return 1
+    done
+
+    return 1
+}
+
+find_push_command() {
+    local pid=$PPID
+    local depth=0
+    local command
+
+    while is_positive_integer "$pid" && [ "$pid" -gt 1 ] && [ "$depth" -lt 10 ]; do
+        command=$(parent_command "$pid")
+        if is_git_push_command "$command"; then
+            printf '%s\n' "$command"
+            return 0
+        fi
+
+        pid=$(parent_pid "$pid")
+        depth=$((depth + 1))
+    done
+
+    return 1
+}
+
+matches_current_remote() {
+    local candidate=$1
+
+    if [ -n "${PRE_COMMIT_REMOTE_NAME-}" ] && [ "$candidate" = "$PRE_COMMIT_REMOTE_NAME" ]; then
+        return 0
+    fi
+
+    [ "$candidate" = "$remote_url" ]
+}
+
+push_explicitly_specifies_remote() {
+    local command
+    local -a parts
+    local expect_repo_value=0
+    local expect_option_value=0
+    local token
+    local push_index=-1
+
+    command=$(find_push_command) || return 1
+    read -r -a parts <<< "$command" || true
+
+    for ((i = 0; i < ${#parts[@]}; i++)); do
+        if [ "${parts[$i]}" = "push" ]; then
+            push_index=$i
+            break
+        fi
+    done
+
+    if [ "$push_index" -lt 0 ]; then
+        return 1
+    fi
+
+    for ((i = push_index + 1; i < ${#parts[@]}; i++)); do
+        token=${parts[$i]}
+
+        if [ "$expect_repo_value" -eq 1 ]; then
+            matches_current_remote "$token" && return 0
+            expect_repo_value=0
+            continue
+        fi
+
+        if [ "$expect_option_value" -eq 1 ]; then
+            expect_option_value=0
+            continue
+        fi
+
+        case "$token" in
+            --)
+                i=$((i + 1))
+                if [ "$i" -lt "${#parts[@]}" ] && matches_current_remote "${parts[$i]}"; then
+                    return 0
+                fi
+                return 1
+                ;;
+            --repo=*)
+                matches_current_remote "${token#--repo=}"
+                return
+                ;;
+            --repo)
+                expect_repo_value=1
+                continue
+                ;;
+            --receive-pack | --exec | --push-option | -o)
+                expect_option_value=1
+                continue
+                ;;
+            --receive-pack=* | --exec=* | --push-option=* | -o?*)
+                continue
+                ;;
+            -*)
+                continue
+                ;;
+            *)
+                matches_current_remote "$token"
+                return
+                ;;
+        esac
+    done
+
+    return 1
+}
+
 if [ $# -eq 0 ]; then
     echo "Error: No forbidden remote URL parts specified for this hook." >&2
     exit 1
@@ -13,6 +157,10 @@ if [ -z "$remote_url" ]; then
     echo "Error: PRE_COMMIT_REMOTE_URL is not set. Cannot check remote." >&2
     # Exit 1 to be safe and indicate an error.
     exit 1
+fi
+
+if push_explicitly_specifies_remote; then
+    exit 0
 fi
 
 for forbidden_url_part in "$@"; do

--- a/tests/forbidden-push-remote.bats
+++ b/tests/forbidden-push-remote.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+setup() {
+    temp=$(mktemp -d)
+    export PROJ="$temp"
+    mkdir -p "$PROJ/bin"
+    export PATH="$PROJ/bin:$PATH"
+    unset PRE_COMMIT_REMOTE_NAME
+    unset PRE_COMMIT_REMOTE_URL
+    unset MOCK_PS_DEFAULT_PID
+}
+
+teardown() {
+    rm -rf "$PROJ"
+    unset PROJ
+}
+
+mock_ps() {
+cat << 'EOF' > "$PROJ"/bin/ps
+#!/usr/bin/env bash
+set -eu
+
+if [ "$#" -ne 4 ] || [ "$1" != "-o" ] || [ "$3" != "-p" ]; then
+    exit 254
+fi
+
+field=${2%=}
+pid=$4
+
+if [ "$field" != "command" ] && [ "$field" != "ppid" ]; then
+    exit 253
+fi
+
+var_name="MOCK_PS_${field^^}_$pid"
+if [ -n "${!var_name-}" ]; then
+    printf '%s\n' "${!var_name}"
+    exit 0
+fi
+
+if [ -n "${MOCK_PS_DEFAULT_PID-}" ]; then
+    var_name="MOCK_PS_${field^^}_${MOCK_PS_DEFAULT_PID}"
+    if [ -n "${!var_name-}" ]; then
+        printf '%s\n' "${!var_name}"
+        exit 0
+    fi
+fi
+
+exit 1
+EOF
+chmod +x "$PROJ"/bin/ps
+}
+
+@test 'forbids pushing to forbidden remote when using default push target' {
+    export PRE_COMMIT_REMOTE_NAME=origin
+    export PRE_COMMIT_REMOTE_URL=https://github.com/some-org/repo.git
+    export MOCK_PS_DEFAULT_PID=100
+    export MOCK_PS_COMMAND_100='python -m pre_commit.commands.hook_impl'
+    export MOCK_PS_PPID_100=200
+    export MOCK_PS_COMMAND_200='git push'
+    export MOCK_PS_PPID_200=1
+    mock_ps
+
+    run ./forbidden-push-remote.sh 'github.com/some-org/'
+
+    [ "$status" -eq 1 ]
+    [ "$output" = "Push to remote 'https://github.com/some-org/repo.git' is forbidden because it contains 'github.com/some-org/'." ]
+}
+
+@test 'allows push when remote is explicitly specified' {
+    export PRE_COMMIT_REMOTE_NAME=origin
+    export PRE_COMMIT_REMOTE_URL=https://github.com/some-org/repo.git
+    export MOCK_PS_DEFAULT_PID=100
+    export MOCK_PS_COMMAND_100='python -m pre_commit.commands.hook_impl'
+    export MOCK_PS_PPID_100=200
+    export MOCK_PS_COMMAND_200='git push -u origin HEAD'
+    export MOCK_PS_PPID_200=1
+    mock_ps
+
+    run ./forbidden-push-remote.sh 'github.com/some-org/'
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test 'does not treat refspec as an explicit remote' {
+    export PRE_COMMIT_REMOTE_NAME=origin
+    export PRE_COMMIT_REMOTE_URL=https://github.com/some-org/repo.git
+    export MOCK_PS_DEFAULT_PID=100
+    export MOCK_PS_COMMAND_100='python -m pre_commit.commands.hook_impl'
+    export MOCK_PS_PPID_100=200
+    export MOCK_PS_COMMAND_200='git push HEAD:main'
+    export MOCK_PS_PPID_200=1
+    mock_ps
+
+    run ./forbidden-push-remote.sh 'github.com/some-org/'
+
+    [ "$status" -eq 1 ]
+    [ "$output" = "Push to remote 'https://github.com/some-org/repo.git' is forbidden because it contains 'github.com/some-org/'." ]
+}


### PR DESCRIPTION
## Summary
- skip the forbidden push remote check when `git push` explicitly targets the current remote
- inspect the parent `git push` command so the hook can distinguish an explicit remote from a refspec-only push
- add bats coverage for the default push target, explicit remote, and refspec cases
- document the explicit-remote behavior in `README.md`

## Testing
- make test
